### PR TITLE
Disable node/no-unsupported-features/es-*

### DIFF
--- a/configs/js.js
+++ b/configs/js.js
@@ -99,5 +99,7 @@ module.exports = {
     "switch-colon-spacing": [ "warn", { before: false, after: true }],
 
     "no-console": "off",
+    "node/no-unsupported-features/es-builtins": "off",
+    "node/no-unsupported-features/es-syntax": "off",
   },
 };


### PR DESCRIPTION
This rules disallows to use import in the code including code for browser & babel